### PR TITLE
Added organiser logo support to confirmation emails

### DIFF
--- a/app/Mail/SendAttendeeInviteMail.php
+++ b/app/Mail/SendAttendeeInviteMail.php
@@ -14,6 +14,7 @@ class SendAttendeeInviteMail extends Mailable
     use Queueable, SerializesModels;
 
     public $attendee;
+    public $email_logo;
 
     /**
      * Create a new message instance.
@@ -23,6 +24,7 @@ class SendAttendeeInviteMail extends Mailable
     public function __construct(Attendee $attendee)
     {
         $this->attendee = $attendee;
+        $this->email_logo = $attendee->event->organiser->full_logo_path;
     }
 
     /**

--- a/app/Mail/SendMessageToAttendeesMail.php
+++ b/app/Mail/SendMessageToAttendeesMail.php
@@ -17,6 +17,7 @@ class SendMessageToAttendeesMail extends Mailable
     public $content;
     public $event;
     public $attendee;
+    public $email_logo;
 
     /**
      * Create a new message instance.
@@ -29,6 +30,7 @@ class SendMessageToAttendeesMail extends Mailable
         $this->content = $content;
         $this->event = $event;
         $this->attendee = $attendee;
+        $this->email_logo = $event->organiser->full_logo_path;
     }
 
     /**

--- a/app/Mail/SendOrderAttendeeTicketMail.php
+++ b/app/Mail/SendOrderAttendeeTicketMail.php
@@ -18,6 +18,7 @@ class SendOrderAttendeeTicketMail extends Mailable
      * @var Attendee
      */
     public $attendee;
+    public $email_logo;
 
     /**
      * Create a new message instance.
@@ -27,6 +28,7 @@ class SendOrderAttendeeTicketMail extends Mailable
     public function __construct(Attendee $attendee)
     {
         $this->attendee = $attendee;
+        $this->email_logo = $attendee->event->organiser->full_logo_path;
     }
 
     /**

--- a/app/Mail/SendOrderConfirmationMail.php
+++ b/app/Mail/SendOrderConfirmationMail.php
@@ -27,6 +27,8 @@ class SendOrderConfirmationMail extends Mailable
      */
     public $orderService;
 
+    public $email_logo;
+
     /**
      * Create a new message instance.
      *
@@ -34,6 +36,7 @@ class SendOrderConfirmationMail extends Mailable
      */
     public function __construct(Order $order, OrderService $orderService)
     {
+        $this->email_logo = $order->event->organiser->full_logo_path;
         $this->order = $order;
         $this->orderService = $orderService;
     }

--- a/app/Mail/SendOrderNotificationMail.php
+++ b/app/Mail/SendOrderNotificationMail.php
@@ -27,6 +27,8 @@ class SendOrderNotificationMail extends Mailable
      */
     public $orderService;
 
+    public $email_logo;
+
     /**
      * Create a new message instance.
      *
@@ -36,6 +38,7 @@ class SendOrderNotificationMail extends Mailable
     {
         $this->order = $order;
         $this->orderService = $orderService;
+        $this->email_logo = $order->event->organiser->full_logo_path;
     }
 
     /**


### PR DESCRIPTION
Receiving emails with the Attendize logo can be confusing for attendees.